### PR TITLE
Fix dos mocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /target/
+.idea/
+.settings/
+*.iml
+.classpath
+.project

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>2.10.0</version>
+            <scope>test</scope>
 		</dependency>
 
 		<!-- Hibernate -->
@@ -118,6 +119,11 @@
 					<failOnMissingWebXml>false</failOnMissingWebXml>
 				</configuration>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.20.1</version>
+            </plugin>
 		</plugins>
 	</build>
 

--- a/src/test/java/br/com/ab/Trello/test/UserTests.java
+++ b/src/test/java/br/com/ab/Trello/test/UserTests.java
@@ -1,78 +1,101 @@
 package br.com.ab.Trello.test;
 
-import static org.junit.Assert.assertEquals;
-
-import javax.persistence.EntityManager;
-
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import br.com.ab.Trello.dao.UserDao;
 import br.com.ab.Trello.model.User;
 import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class UserTests {
 
-	@Test(expected = ExceptionInInitializerError.class)
-	public void addUserFailureTest() {
+    private UserDao userDao;
 
-		UserDao userDao = new UserDao();
+    @Before
+    public void setup() {
+        userDao = new UserDao();
+    }
 
-		User user = new User("Andrey", "Test");
-		user.setId(1);
+    @Test(expected = ExceptionInInitializerError.class)
+    public void addUserFailureTest() {
 
-		EntityManager entityManager = new JPAUtil().getEntityManager();
+        User user = new User("Andrey", "Test");
+        user.setId(1);
 
-		userDao.addUser(user, entityManager);
-	}
+        EntityManager entityManager = new JPAUtil().getEntityManager();
 
-	@SuppressWarnings("deprecation")
-	@Test
-	public void addUserSucessfullyTest() {
+        userDao.addUser(user, entityManager);
+    }
 
-		UserDao userDao = new UserDao();
-		userDao.setEntityManager(Mockito.mock(EntityManager.class));
+    @SuppressWarnings("deprecation")
+    @Test
+    public void addUserSucessfullyTest() {
 
-		// ArgumentCaptor<SuccessfulPaymentEvent> argumentCaptor =
-		// ArgumentCaptor.forClass(SuccessfulPaymentEvent.class);
-		User user = new User("Andrey", "Test");
-		userDao.addUser(user);
+        EntityManager entityManager = Mockito.mock(EntityManager.class);
 
-		Mockito.verify(userDao.getEntityManager()).persist(user);
+        Mockito.doAnswer(new MockUserAnswer(1, "Andrey", "Test"))
+                .when(entityManager)
+                .persist(Mockito.any(User.class));
 
-		int user_Id = 14;
+        userDao.setEntityManager(entityManager);
 
-		Assert.assertEquals(user.getId().intValue(), user_Id);
-	}
+        // ArgumentCaptor<SuccessfulPaymentEvent> argumentCaptor =
+        // ArgumentCaptor.forClass(SuccessfulPaymentEvent.class);
+        User user = new User("Andrey", "Test");
+        userDao.addUser(user);
 
-	@Test
-	public void testDBConnection(){
-		
-		EntityManager entityManager = Mockito.mock(EntityManager.class);
-		String usernameTest = "Andrey";
-		String databaseReturn = (String)entityManager.createQuery("SELECT username FROM user WHERE user_id = 1").getSingleResult();
-		
-		assertEquals(usernameTest, databaseReturn);
-	}
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
+        Mockito.verify(userDao.getEntityManager()).persist(user);
+
+        Assert.assertSame(user.getId(), 1);
+        Assert.assertNotSame(user.getId(), 2);
+    }
+
+    @Test
+    public void testDBConnection() {
+
+        EntityManager entityManager = Mockito.mock(EntityManager.class);
+        Query mockedQuery = Mockito.mock(Query.class);
+        final String queryString = "SELECT username FROM user WHERE user_id = 1";
+        User user = new User("Andrey", "Test");
+        user.setId(1);
+
+        Mockito.when(entityManager.createQuery(queryString)).thenReturn(mockedQuery);
+        Mockito.when(mockedQuery.getSingleResult()).thenReturn(user);
+
+        Query query = entityManager.createQuery(queryString);
+        User databaseReturn = (User) query.getSingleResult();
+
+        assertNotNull(databaseReturn);
+        assertEquals(user, databaseReturn);
+    }
+
+    private class MockUserAnswer implements Answer<Void> {
+        private final Integer id;
+        private final String login;
+        private final String pass;
+
+        private MockUserAnswer(Integer id, String login, String pass) {
+            this.id = id;
+            this.login = login;
+            this.pass = pass;
+        }
+
+
+        @Override
+        public Void answer(InvocationOnMock invocation) throws Throwable {
+            User user = (User) invocation.getArgument(0);
+            user.setId(id);
+            user.setLogin(login);
+            user.setPassword(pass);
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
Aproveitei a acertei o `.gitignore` e o `pom.xml`. Por estar usando uma versão antiga do plugin de testes, Surefire, os testes não estavam rodando quando o `mvn package` rodava.

Os mocks precisam ser um pouco mais detalhados, então para cada chamada de método, aparentemente, tem que ter um `Mockito.when()` separado.

Dá uma olhada em  http://www.adam-bien.com/roller/abien/entry/mocking_jpa_entitymanager_with_query e http://www.christophbrill.de/de_DE/unit-testing-with-junit-and-mockito/.

Para o `Answers` eu me baseei nesse exemplo mais simples, https://semaphoreci.com/community/tutorials/stubbing-and-mocking-with-mockito-2-and-junit e criei uma classe interna como referência.

Espero que ajude.